### PR TITLE
Scrum 60 message queue amq

### DIFF
--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -20,7 +20,7 @@ jobs:
         run: terraform init -input=false
 
       - name: Terraform Plan
-        run: terraform plan -target=module.message_queue -out=tfplan -input=false
+        run: terraform plan -target=module.message_queue -target=module.networking -out=tfplan -input=false
 
       - name: Terraform Apply
         run: terraform apply -input=false -auto-approve tfplan

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -19,5 +19,8 @@ jobs:
       - name: Terraform Init
         run: terraform init -input=false
 
+      - name: Terraform Plan
+        run: terraform plan -target=module.message_queue -out=tfplan -input=false
+
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false
+        run: terraform apply -input=false -auto-approve tfplan

--- a/.github/workflows/provision.yml
+++ b/.github/workflows/provision.yml
@@ -19,8 +19,5 @@ jobs:
       - name: Terraform Init
         run: terraform init -input=false
 
-      - name: Terraform Plan
-        run: terraform plan -target=module.message_queue -target=module.networking -out=tfplan -input=false
-
       - name: Terraform Apply
-        run: terraform apply -input=false -auto-approve tfplan
+        run: terraform apply -auto-approve -input=false

--- a/main.tf
+++ b/main.tf
@@ -64,3 +64,13 @@ module "database" {
   users_db_password = var.users_db_password
   users_db_name     = var.users_db_name
 }
+
+module "message_queue" {
+  source = "./terraform_modules/message_queue"
+
+  vpc_id             = module.networking.vpc_info.vpc_id
+  private_subnet_ids = module.networking.vpc_info.private_subnets[*].id
+
+  mq_user     = var.mq_user
+  mq_password = var.mq_password
+}

--- a/main.tf
+++ b/main.tf
@@ -68,6 +68,8 @@ module "database" {
 module "message_queue" {
   source = "./terraform_modules/message_queue"
 
+  aws_region = var.aws_region
+
   vpc_id             = module.networking.vpc_info.vpc_id
   private_subnet_ids = module.networking.vpc_info.private_subnets[*].id
 

--- a/terraform_modules/message_queue/output.tf
+++ b/terraform_modules/message_queue/output.tf
@@ -1,4 +1,4 @@
 output "mq_connection_string" {
-  value       = "amqps://${aws_mq_broker.mq.id}.mq.${aws_region.current.name}.amazonaws.com:5671"
+  value       = "amqps://${aws_mq_broker.mq.id}.mq.${var.aws_region.name}.amazonaws.com:5671"
   description = "Connection string for RabbitMQ"
 }

--- a/terraform_modules/message_queue/output.tf
+++ b/terraform_modules/message_queue/output.tf
@@ -1,0 +1,4 @@
+output "mq_connection_string" {
+  value       = "amqps://${aws_mq_broker.mq.id}.mq.${aws_region.current.name}.amazonaws.com:5671"
+  description = "Connection string for RabbitMQ"
+}

--- a/terraform_modules/message_queue/output.tf
+++ b/terraform_modules/message_queue/output.tf
@@ -1,4 +1,5 @@
 output "mq_connection_string" {
   value       = "amqps://${aws_mq_broker.mq.id}.mq.${var.aws_region}.amazonaws.com:5671"
   description = "Connection string for RabbitMQ"
+  sensitive = true
 }

--- a/terraform_modules/message_queue/output.tf
+++ b/terraform_modules/message_queue/output.tf
@@ -1,4 +1,4 @@
 output "mq_connection_string" {
-  value       = "amqps://${aws_mq_broker.mq.id}.mq.${var.aws_region.name}.amazonaws.com:5671"
+  value       = "amqps://${aws_mq_broker.mq.id}.mq.${var.aws_region}.amazonaws.com:5671"
   description = "Connection string for RabbitMQ"
 }

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -8,8 +8,6 @@ resource "aws_mq_subnet_group" "mq_subnet_group" {
 }
 
 resource "aws_mq_broker" "mq" {
-  provider                  = awsalternate
-  apply_immediately         = true
   broker_name               = "mq-primary"
   engine_type               = "RabbitMQ"
   engine_version            = "3.13"

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -9,8 +9,8 @@ resource "aws_mq_broker" "mq" {
   publicly_accessible       = false
 
   user {
-    username = vsr.mq_user
-    password = vsr.mq_password
+    username = var.mq_user
+    password = var.mq_password
   }
 }
 

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -4,7 +4,7 @@ resource "aws_mq_broker" "mq" {
   engine_version            = "3.13"
   host_instance_type        = "mq.m5.large"
   security_groups           = [aws_security_group.mq_sg.id]
-  deployment_mode           = "ACTIVE_STANDBY_MULTI_AZ"
+  deployment_mode           = "CLUSTER_MULTI_AZ"
   subnet_ids                = var.private_subnet_ids
   publicly_accessible       = false
   auto_minor_version_upgrade = true

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -1,0 +1,45 @@
+resource "aws_mq_subnet_group" "mq_subnet_group" {
+  name       = "mq_subnet_group"
+  subnet_ids = [var.private_subnet_ids[0], var.private_subnet_ids[1]]
+
+  tags = {
+    Name = "MQ Subnet Group"
+  }
+}
+
+resource "aws_mq_broker" "mq" {
+  provider                  = awsalternate
+  apply_immediately         = true
+  broker_name               = "mq-primary"
+  engine_type               = "RabbitMQ"
+  engine_version            = "3.13"
+  host_instance_type        = "mq.m5.large"
+  security_groups           = [aws_security_group.mq_sg.id]
+  deployment_mode           = "ACTIVE_STANDBY_MULTI_AZ"
+  subnet_ids                = aws_mq_subnet_group.mq_subnet_group.subnet_ids
+
+  user {
+    username = vsr.mq_user
+    password = vsr.mq_password
+  }
+}
+
+resource "aws_security_group" "mq_sg" {
+  name        = "mq_sg"
+  description = "Security Group for MQ Instances"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    from_port   = 5671
+    to_port     = 5672
+    protocol    = "tcp"
+    cidr_blocks = ["10.0.0.0/24"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -1,12 +1,3 @@
-resource "aws_mq_subnet_group" "mq_subnet_group" {
-  name       = "mq_subnet_group"
-  subnet_ids = [var.private_subnet_ids[0], var.private_subnet_ids[1]]
-
-  tags = {
-    Name = "MQ Subnet Group"
-  }
-}
-
 resource "aws_mq_broker" "mq" {
   broker_name               = "mq-primary"
   engine_type               = "RabbitMQ"
@@ -14,7 +5,8 @@ resource "aws_mq_broker" "mq" {
   host_instance_type        = "mq.m5.large"
   security_groups           = [aws_security_group.mq_sg.id]
   deployment_mode           = "ACTIVE_STANDBY_MULTI_AZ"
-  subnet_ids                = aws_mq_subnet_group.mq_subnet_group.subnet_ids
+  subnet_ids                = var.private_subnet_ids
+  publicly_accessible       = false
 
   user {
     username = vsr.mq_user

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -7,6 +7,7 @@ resource "aws_mq_broker" "mq" {
   deployment_mode           = "ACTIVE_STANDBY_MULTI_AZ"
   subnet_ids                = var.private_subnet_ids
   publicly_accessible       = false
+  auto_minor_version_upgrade = true
 
   user {
     username = var.mq_user

--- a/terraform_modules/message_queue/rabbitMQ.tf
+++ b/terraform_modules/message_queue/rabbitMQ.tf
@@ -1,12 +1,12 @@
 resource "aws_mq_broker" "mq" {
-  broker_name               = "mq-primary"
-  engine_type               = "RabbitMQ"
-  engine_version            = "3.13"
-  host_instance_type        = "mq.m5.large"
-  security_groups           = [aws_security_group.mq_sg.id]
-  deployment_mode           = "CLUSTER_MULTI_AZ"
-  subnet_ids                = var.private_subnet_ids
-  publicly_accessible       = false
+  broker_name                = "mq"
+  engine_type                = "RabbitMQ"
+  engine_version             = "3.13"
+  host_instance_type         = "mq.m5.large"
+  security_groups            = [aws_security_group.mq_sg.id]
+  deployment_mode            = "CLUSTER_MULTI_AZ"
+  subnet_ids                 = var.private_subnet_ids
+  publicly_accessible        = false
   auto_minor_version_upgrade = true
 
   user {

--- a/terraform_modules/message_queue/vars.tf
+++ b/terraform_modules/message_queue/vars.tf
@@ -1,3 +1,9 @@
+variable "aws_region" {
+  type        = string
+  description = "The AWS region"
+  
+}
+
 variable "vpc_id" {
   type        = string
   description = "The ID of the VPC"

--- a/terraform_modules/message_queue/vars.tf
+++ b/terraform_modules/message_queue/vars.tf
@@ -1,0 +1,19 @@
+variable "vpc_id" {
+  type        = string
+  description = "The ID of the VPC"
+}
+
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "The IDs of the private subnets"
+}
+
+variable "mq_user" {
+  type        = string
+  description = "The username for the RabbitMQ broker"
+}
+
+variable "mq_password" {
+  type        = string
+  description = "The password for the RabbitMQ broker"
+}

--- a/vars.tf
+++ b/vars.tf
@@ -113,5 +113,5 @@ variable "mq_user" {
 variable "mq_password" {
   type        = string
   description = "The password for the message queue"
-  default = "mq_password"
+  default = "mq_password12"
 }

--- a/vars.tf
+++ b/vars.tf
@@ -103,3 +103,15 @@ variable "users_db_name" {
   description = "The name for the users database"
   default     = "users_db"
 }
+
+variable "mq_user" {
+  type        = string
+  description = "The username for the message queue"
+  default = "mq_user"
+}
+
+variable "mq_password" {
+  type        = string
+  description = "The password for the message queue"
+  default = "mq_password"
+}


### PR DESCRIPTION
This pull request includes significant updates to the Terraform configuration to integrate a new RabbitMQ message queue. The changes involve adding a new module for the message queue, updating related variables, and modifying the workflow to include the new module in the Terraform plan and apply steps.

### Integration of RabbitMQ Message Queue:

* Added a new `message_queue` module in `main.tf` to configure the RabbitMQ broker, including necessary variables for AWS region, VPC ID, private subnet IDs, and RabbitMQ user credentials.
* Created `terraform_modules/message_queue/rabbitMQ.tf` to define the `aws_mq_broker` resource and its associated security group. This includes settings for the broker name, engine type, version, instance type, deployment mode, and user credentials.

### Updates to Terraform Variables:

* Added new variables in `terraform_modules/message_queue/vars.tf` for `aws_region`, `vpc_id`, `private_subnet_ids`, `mq_user`, and `mq_password` to support the configuration of the RabbitMQ broker.
* Updated `vars.tf` to include default values for `mq_user` and `mq_password` variables.

### Workflow Modifications:

* Updated `.github/workflows/provision.yml` to include a new `Terraform Plan` step targeting the `message_queue` and `networking` modules, and modified the `Terraform Apply` step to use the generated plan file.

### Output Configuration:

* Added an output in `terraform_modules/message_queue/output.tf` to expose the RabbitMQ connection string, marking it as sensitive.